### PR TITLE
Fix Screenshot Bottom Cutoff

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,7 +52,7 @@ button:hover, button:focus {
     margin-top: 20px;
     text-align: left;
     background-color: #f9f9f9;
-    padding: 10px;
+    padding: 20px;
     border-radius: 5px;
 }
 


### PR DESCRIPTION
There was a problem with cutting off the screenshot. I changed the padding in the results section of the CCS file to solve the problem.

![my-cash-cascading-results (1)](https://github.com/jvholmes87/Cash-Cascading/assets/147929460/2da34db5-7485-497f-93c7-8e2b9f5b3300)
![my-cash-cascading-results (19)](https://github.com/jvholmes87/Cash-Cascading/assets/147929460/ed0790aa-b6ea-4adb-9a0e-9bb6527f7e7b)
